### PR TITLE
Fix Synchronize Locally and Remotely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+.DEFAULT_GOAL := apply
+.PHONY: apply
+
 DEFAULT_IMAGE:=centos7
 IMAGE:=$(shell echo "$${IMAGE:-$(DEFAULT_IMAGE)}")
 
@@ -18,3 +21,15 @@ test: start
 	@docker exec $(IMAGE) ansible-galaxy install -r /etc/ansible/roles/default/tests/requirements.yml
 	@docker exec $(IMAGE) env ANSIBLE_FORCE_COLOR=yes \
 		ansible-playbook /etc/ansible/roles/default/tests/playbook.yml
+
+prepare-apply:
+	@mkdir -p target/ .ansible/galaxy-roles
+	@rsync --exclude=.ansible/galaxy-roles -a ./ .ansible/galaxy-roles/rust-dev/
+	@ansible-galaxy install -p .ansible/galaxy-roles -r tests/requirements.yml
+
+
+apply: prepare-apply
+	@ansible-playbook -i localhost, -c local --ask-become-pass local.yml
+
+apply-ssh: prepare-apply
+	@ansible-playbook -i localhost, --ask-become-pass local.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 retry_files_enabled = false
+roles_path = .ansible/galaxy-roles:.ansible/roles:/etc/ansible/roles
 
 [galaxy]
 role_skeleton_ignore = ^.git(ignore)?$,^\.travis\.yml$,^tests,^(Vagrantfile|vagrant\.yml|\.vagrant)$,^Makefile$

--- a/local.yml
+++ b/local.yml
@@ -1,0 +1,16 @@
+---
+- name: determine local user name
+  hosts: all
+  tasks:
+    - name: detect local user
+      local_action: command whoami
+      register: host_user
+
+    - name: set local user fact
+      set_fact: local_user={{ host_user.stdout }}
+
+- name: apply config locally
+  hosts: all
+  roles:
+    - role: rust-dev
+      rust_user: "{{ local_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,12 +60,30 @@
     group: root
   become: true
 
-- name: sync man pages
+- name: establish connection type
+  set_fact:
+    is_connection_local: |-
+      {%- if ansible_connection == "local" -%}
+        true
+      {%- else -%}
+        false
+      {%- endif -%}
+
+- name: sync man pages (local)
+  synchronize:
+    src: "{{ rust_user_home }}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/man/man1/"
+    dest: "/usr/local/share/man/man1/"
+  when: is_connection_local
+  become: true
+
+- name: sync man pages (remote)
   synchronize:
     src: "{{ rust_user_home }}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/man/man1/"
     dest: "/usr/local/share/man/man1/"
   delegate_to: "{{ inventory_hostname }}"
+  when: not is_connection_local
   become: true
+
 
 - name: install c compiler
   package: name="{{ rust_c_compiler_package }}" state=present


### PR DESCRIPTION
When over SSH, delegate to the remote host. When local, no delegation is necessary.