### PR TITLE
Disable Code-Completion by Default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ rust_addtl_system_packages: []
 rust_code_completion: true
 
 rust_user_path: "/home/{{ rust_user }}/.local/bin:/home/{{ rust_user }}/.cargo/bin:/usr/local/bin/:/usr/bin:/bin"
+
+rust_install_racer: false
+rust_install_rls: false

--- a/tasks/code-completion.yml
+++ b/tasks/code-completion.yml
@@ -8,13 +8,14 @@
   register: racer
   become: true
   become_user: "{{ rust_user }}"
+  when: rust_install_racer | bool
 
 - name: install racer
   command: "cargo install racer"
   environment:
     PATH: "{{ rust_user_path }}"
   register: racer_exec
-  when: racer.rc != 0
+  when: rust_install_racer and racer.rc != 0
   become: true
   become_user: "{{ rust_user }}"
 
@@ -27,11 +28,12 @@
   register: rls
   become: true
   become_user: "{{ rust_user }}"
+  when: rust_install_rls | bool
 
 - name: install rls
   command: "rustup component add rls-preview rust-analysis rust-src"
   environment:
     PATH: "{{ rust_user_path }}"
-  when: rls.rc != 0
+  when: rust_install_rls and rls.rc != 0
   become: true
   become_user: "{{ rust_user }}"

--- a/tests/goss.d/files.yml
+++ b/tests/goss.d/files.yml
@@ -5,8 +5,13 @@ file:
   '/home/docker/.cargo/bin/cargo': { exists: true }
   '/home/docker/.cargo/bin/rustc': { exists: true }
 
+{{ if eq (getEnv "INSTALL_RACER" "false") "true" }}
   '/home/docker/.cargo/bin/racer': { exists: true }
+{{ end }}
+
+{{ if eq (getEnv "INSTALL_RLS" "false") "true" }}
   '/home/docker/.cargo/bin/rls': { exists: true }
+{{ end }}
 
   '/usr/local/share/man/man1/cargo.1': { exists: true }
   '/usr/local/share/man/man1/rustc.1': { exists: true }

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -7,13 +7,34 @@
     - name: create user
       user: name={{ container_user }} comment="Container User" state=present
 
-- name: build
+# install with defaults (no racer, no rls)
+- name: build (default)
   hosts: localhost
   roles:
     - role: default
       rust_user: docker
 
-- name: test
+# test that racer and rls are not installed
+- name: test (default)
+  hosts: localhost
+  roles:
+    - role: degoss
+      degoss_clean: false
+      degoss_debug: true
+      goss_file: goss.yml
+      goss_addtl_dirs: [goss.d]
+      goss_env_vars: {}
+
+# install with racer and rls
+- name: build (with racer/rls)
+  hosts: localhost
+  roles:
+    - role: default
+      rust_user: docker
+      rust_install_racer: true
+      rust_install_rls: true
+
+- name: test (with racer/rls)
   hosts: localhost
   vars: {}
   roles:
@@ -22,4 +43,6 @@
       degoss_debug: true
       goss_file: goss.yml
       goss_addtl_dirs: [goss.d]
-      goss_env_vars: {}
+      goss_env_vars:
+        INSTALL_RACER: true
+        INSTALL_RLS: true


### PR DESCRIPTION
Racer and RLS should be opt-in. This will trigger a major release, being backward incompatible in that the most recent release installs these by default. The new default will be opt-in.